### PR TITLE
Reflect .value, .className, and .id to attributes

### DIFF
--- a/src/lib/parse5-utils.ts
+++ b/src/lib/parse5-utils.ts
@@ -65,7 +65,7 @@ export function insertNode(
   if (!parent.childNodes) {
     parent.childNodes = [];
   }
-  let newNodes = [];
+  let newNodes: any[] = [];
   let removedNode = replace ? parent.childNodes[index] : null;
   if (newNode) {
     if (isDocumentFragment(newNode)) {

--- a/src/lib/reflected-attributes.ts
+++ b/src/lib/reflected-attributes.ts
@@ -26,7 +26,7 @@
  */
 const reflectedAttributesSource: (string|string[])[][] = [
   [['input', 'select'], 'value'],
-  ['*', ['classname', 'class'], 'id']
+  ['*', ['className', 'class'], 'id']
 ];
 
 /**

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { TemplateResult } from 'lit-html';
-import {marker, markerRegex} from 'lit-html/lib/template.js';
+import { TemplateResult, nothing } from 'lit-html';
+import {marker, markerRegex, lastAttributeNameRegex} from 'lit-html/lib/template.js';
 
 // types only
 import {Node, DefaultTreeDocumentFragment, DefaultTreeNode} from 'parse5';
@@ -84,6 +84,8 @@ export async function* render(value: unknown, childRenderer?: ChildRenderer|unde
       // do nothing
     } else if (isRepeatDirective(value)) {
       yield* (value as RepeatPreRenderer)(childRenderer);
+    } else if (value === nothing) {
+      // yield nothing
     } else {
       // TODO: convert value to string, handle arrays, directives, etc.
       yield String(value);
@@ -207,8 +209,8 @@ export async function* renderInternal(result: TemplateResult, childRenderer: Chi
             yield html.substring(lastOffset!, attrNameStartOffset);
 
             if (attr.name.startsWith('.')) {
+              const propertyName = lastAttributeNameRegex.exec(result.strings[partIndex])![2].slice(1);
               const value = result.values[partIndex++];
-              const propertyName = attr.name.substring(1, attr.name.length - 5);
               if (instance !== undefined) {
                 (instance as any)[propertyName] = value;
               }

--- a/src/test/render-test-module.ts
+++ b/src/test/render-test-module.ts
@@ -52,6 +52,7 @@ export const templateWithMultiBindingAttributeExpression = (x: string, y: string
 
 export const inputTemplateWithValueProperty = (x: any) => html`<input .value=${x}>`;
 export const elementTemplateWithClassNameProperty = (x: any) => html`<div .className=${x}></div>`;
+export const elementTemplateWithClassnameProperty = (x: any) => html`<div .classname=${x}></div>`;
 export const elementTemplateWithIDProperty = (x: any) => html`<div .id=${x}></div>`;
 
 /* Nested Templates */

--- a/src/test/render_test.ts
+++ b/src/test/render_test.ts
@@ -120,6 +120,12 @@ test('HTMLElement.className', async (t: tapelib.Test) => {
   t.equal(result, `<!--lit-part I7NxrdZ/Zxo=--><div class="foo" __lit-attr="1"></div><!--/lit-part-->`);
 });
 
+test('HTMLElement.classname does not reflect', async (t: tapelib.Test) => {
+  const {render, elementTemplateWithClassnameProperty} = await setup();
+  const result = await render(elementTemplateWithClassnameProperty('foo'));
+  t.equal(result, `<!--lit-part I7NxrbZzZGA=--><div  __lit-attr="1"></div><!--/lit-part-->`);
+});
+
 test('HTMLElement.id', async (t: tapelib.Test) => {
   const {render, elementTemplateWithIDProperty} = await setup();
   const result = await render(elementTemplateWithIDProperty('foo'));
@@ -226,7 +232,8 @@ test('dynamic slot, unrendered', async (t: tapelib.Test) => {
   const {render, dynamicSlot} = await setup();
   const result = await render(dynamicSlot(false));
   // TODO: this is a bit wrong. See the comment in the "no slot" test
-  t.equal(result, `<!--lit-part UB+QgozkbOc=--><test-dynamic-slot  __lit-attr="1"><!--lit-part BRUAAAUVAAA=--><!--lit-part Pz0gobCCM4E=--><p>Hi</p><!--/lit-part--><!--/lit-part--></test-dynamic-slot><!--/lit-part-->`);
+  // (<p>Hi</p> should be hidden somehow)
+  t.equal(result, `<!--lit-part UB+QgozkbOc=--><test-dynamic-slot  __lit-attr="1"><!--lit-part BRUAAAUVAAA=--><!--lit-part--><!--/lit-part--><!--/lit-part--><p>Hi</p></test-dynamic-slot><!--/lit-part-->`);
 });
 
 


### PR DESCRIPTION
Some properties, when set on an HTMLElement, reflect as an attribute. With the server environment being Node, we cannot rely on DOM APIs to do that for us.

This is a concept for mapping out which properties on which elements need to be reflected to attributes when set.