### PR TITLE
Add more tests for value types & fix noChange

### DIFF
--- a/src/lib/render-lit-html.ts
+++ b/src/lib/render-lit-html.ts
@@ -14,7 +14,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {TemplateResult, nothing} from 'lit-html';
+import {TemplateResult, nothing, noChange} from 'lit-html';
 import {
   marker,
   markerRegex,
@@ -181,7 +181,7 @@ export async function* renderValue(
         const templateResult = (instance.instance as any).renderLight();
         yield* renderValue(templateResult, childRenderer, renderInfo);
       }
-    } else if (value === nothing) {
+    } else if (value === nothing || value === noChange) {
       // yield nothing
     } else if (Array.isArray(value)) {
       for (const item of value) {

--- a/src/test/integration/client/basic_test.ts
+++ b/src/test/integration/client/basic_test.ts
@@ -52,7 +52,7 @@ suite('basic', () => {
 
 
   for (const [testName, testSetup] of Object.entries(tests)) {
-    const {render: testRender, expectations, stableSelectors} = testSetup;
+    const {render: testRender, expectations, stableSelectors, expectMutationsOnFirstRender} = testSetup;
 
     const testFn = testSetup.skip ? test.skip : testSetup.only ? test.only : test;
 
@@ -76,14 +76,16 @@ suite('basic', () => {
           hydrate(testRender(...args), container);
           // Hydration should cause no DOM mutations, because it does not
           // actually update the DOM - it just recreates data structures
-          assert.isEmpty(getMutations());
+          assert.isEmpty(getMutations(), 'Hydration should cause no DOM mutations');
           clearMutations();
 
           // After hydration, render() will be operable.
           render(testRender(...args), container);
           // The first render should also cause no mutations, since it's using
           // the same data as the server.
-          assert.isEmpty(getMutations());
+          if (!expectMutationsOnFirstRender) {
+            assert.isEmpty(getMutations(), 'First render should cause no DOM mutations');
+          }
         } else {
           render(testRender(...args), container);
         }

--- a/src/test/integration/tests/basic.ts
+++ b/src/test/integration/tests/basic.ts
@@ -122,6 +122,23 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div'],
   },
 
+  'mix of expressions across multiple attributes': {
+    render(a: any, b: any, c: any, d: any, e: any, f: any) {
+      return html`<div ab="${a} ${b}" x c="${c}" y de="${d} ${e}" f="${f}" z></div>`;
+    },
+    expectations: [
+      {
+        args: ['a', 'b', 'c', 'd', 'e', 'f'],
+        html: '<div ab="a b" x c="c" y de="d e" f="f" z></div>'
+      },
+      {
+        args: ['A', 'B', 'C', 'D', 'E', 'F'],
+        html: '<div ab="A B" x c="C" y de="D E" f="F" z></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
   'property expression': {
     render(x: any) {
       return html`<div .foo=${x}></div>`;

--- a/src/test/integration/tests/basic.ts
+++ b/src/test/integration/tests/basic.ts
@@ -12,49 +12,342 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {html} from 'lit-html';
+import {html, noChange, nothing} from 'lit-html';
 import {repeat} from 'lit-html/directives/repeat.js';
 
 import { SSRTest } from './ssr-test';
 
+const filterNodes = (nodes: ArrayLike<Node>, nodeType: number) =>
+  Array.from(nodes).filter(n => n.nodeType === nodeType);
+
+const testSymbol = Symbol();
+const testObject = {};
+const testArray = [1,2,3];
+const testFunction = () => 'test function';
+
 export const tests: {[name: string] : SSRTest} = {
 
-  'textExpression': {
+  'NodePart accepts a string': {
     render(x: any) {
       return html`<div>${x}</div>`;
     },
     expectations: [
       {
-        args: ['TEST'],
-        html: '<div>TEST</div>'
+        args: ['foo'],
+        html: '<div>foo</div>'
       },
       {
-        args: ['TEST2'],
-        html: '<div>TEST2</div>'
+        args: ['foo2'],
+        html: '<div>foo2</div>'
       }
     ],
     stableSelectors: ['div'],
   },
 
-
-  'twoTextExpression': {
-    render(x: any, y: any) {
-      return html`<div>${x}${y}</div>`;
+  'NodePart accepts a number': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
     },
     expectations: [
       {
-        args: ['A', 'B'],
-        html: '<div>A\n  B</div>'
+        args: [123],
+        html: '<div>123</div>'
       },
       {
-        args: ['C', 'D'],
-        html: '<div>C\n  D</div>'
+        args: [456.789],
+        html: '<div>456.789</div>'
       }
     ],
     stableSelectors: ['div'],
   },
 
-  'nested templates': {
+  'NodePart accepts undefined': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [undefined],
+        html: '<div></div>'
+      },
+      {
+        args: ['foo'],
+        html: '<div>foo</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts null': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [null],
+        html: '<div></div>'
+      },
+      {
+        args: ['foo'],
+        html: '<div>foo</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts noChange': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [noChange],
+        html: '<div></div>'
+      },
+      {
+        args: ['foo'],
+        html: '<div>foo</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts nothing': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [nothing],
+        html: '<div></div>'
+      },
+      {
+        args: ['foo'],
+        html: '<div>foo</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts a symbol': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [Symbol()],
+        html: '<div>Symbol()</div>'
+      },
+      {
+        args: [Symbol()],
+        html: '<div>Symbol()</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts a symbol with a description': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [Symbol('description!')],
+        html: '<div>Symbol(description!)</div>'
+      },
+      {
+        args: [Symbol('description2!')],
+        html: '<div>Symbol(description2!)</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts an object': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [{}],
+        html: '<div>[object Object]</div>'
+      },
+      {
+        args: [{}],
+        html: '<div>[object Object]</div>'
+      }
+    ],
+    // Objects are not dirty-checked before being toString()'ed
+    expectMutationsOnFirstRender: true,
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts an object with a toString method': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [{toString() { return 'toString!'; }}],
+        html: '<div>toString!</div>'
+      },
+      {
+        args: [{toString() { return 'toString2!'; }}],
+        html: '<div>toString2!</div>'
+      }
+    ],
+    // Objects are not dirty-checked before being toString()'ed
+    expectMutationsOnFirstRender: true,
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts a function': {
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [() => { throw new Error(); }],
+        html: '<div>() => { throw new Error(); }</div>'
+      },
+      {
+        args: [() => { throw new Error("2"); }],
+        html: '<div>() => { throw new Error("2"); }</div>'
+      }
+    ],
+    // Functions are not dirty-checked before being toString()'ed
+    expectMutationsOnFirstRender: true,
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts an element': {
+    // document.createElement is not shimmed in the server environment
+    skip: true,
+    render(x: any) {
+      return html`<div>${x}</div>`;
+    },
+    expectations: [
+      {
+        args: [/*document.createElement('span')*/],
+        html: '<div><span></span></div>'
+      },
+      {
+        args: [/*document.createElement('section')*/],
+        html: '<div><section></section></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts array with strings': {
+    render(words: string[]) {
+      return html`<div>${words}</div>`;
+    },
+    expectations: [
+      {
+        args: [['A', 'B', 'C']],
+        html: '<div>A\n  B\n  C</div>'
+      },
+      {
+        args: [['D', 'E', 'F']],
+        html: '<div>D\n  E\n  F</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts array with strings, updated with fewer items': {
+    render(words: string[]) {
+     return html`<div>${words}</div>`;
+    },
+    expectations: [
+      {
+        args: [['A', 'B', 'C']],
+        html: '<div>A\n  B\n  C</div>'
+      },
+      // Attribute hydration not working yet
+      {
+        args: [['D', 'E']],
+        html: '<div>D\n  E</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts array with strings, updated with more items': {
+    render(words: string[]) {
+      return html`<div>${words}</div>`;
+    },
+    expectations: [
+      {
+        args: [['A', 'B', 'C']],
+        html: '<div>A\n  B\n  C</div>'
+      },
+      // Attribute hydration not working yet
+      {
+        args: [['D', 'E', 'F', 'G']],
+        html: '<div>D\n  E\n  F\n  G</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts array with templates': {
+    render(words: string[]) {
+      return html`<ol>${words.map((w) => html`<li>${w}</li>`)}</ol>`;
+    },
+    expectations: [
+      {
+        args: [['A', 'B', 'C']],
+        html: '<ol><li>A</li>\n  <li>B</li>\n  <li>C</li></ol>'
+      },
+      {
+        args: [['D', 'E', 'F']],
+        html: '<ol><li>D</li>\n  <li>E</li>\n  <li>F</li></ol>'
+      }
+    ],
+    stableSelectors: ['ol', 'li'],
+  },
+
+  'NodePart accepts repeat with strings': {
+    skip: true,
+    render(words: string[]) {
+      return html`${repeat(words, (word, i) => `(${i} ${word})`)}`;
+    },
+    expectations: [
+      {
+        args: [['foo', 'bar', 'qux']],
+        html: '(0 foo)\n(1 bar)\n(2 qux)'
+      },
+      // Attribute hydration not working yet
+      {
+        args: [['A', 'B', 'C']],
+        html: '(0 A)(1 B)(2 C)'
+      }
+    ],
+    stableSelectors: [],
+  },
+
+  'NodePart accepts repeat with templates': {
+    skip: true,
+    render(words: string[]) {
+      return html`${repeat(words, (word, i) => html`<p>${i}) ${word}</p>`)}`;
+    },
+    expectations: [
+      {
+        args: [['foo', 'bar', 'qux']],
+        html: '<p>0) foo</p><p>1) bar</p><p>2) qux</p>'
+      },
+      // Attribute hydration not working yet
+      {
+        args: [['A', 'B', 'C']],
+        html: '<p>0) A</p><p>1) B</p><p>2) C</p>'
+      }
+    ],
+    stableSelectors: ['p'],
+  },
+
+  'NodePart accepts nested templates': {
     render(x: any, y: any) {
       return html`<div>${x}${html`<span>${y}</span>`}</div>`;
     },
@@ -71,7 +364,82 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div', 'span'],
   },
 
-  'attributeExpression': {
+  'multiple NodeParts': {
+    render(x: any, y: any) {
+      return html`<div>${x}${y}</div>`;
+    },
+    expectations: [
+      {
+        args: ['A', 'B'],
+        html: '<div>A\n  B</div>'
+      },
+      {
+        args: ['C', 'D'],
+        html: '<div>C\n  D</div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'multiple NodeParts with whitespace': {
+    render(x: any, y: any) {
+      return html`<div>${x} ${y}</div>`;
+    },
+    expectations: [
+      {
+        args: ['A', 'B'],
+        html: '<div>A\n  B</div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          const childNodes = dom.querySelector('div')!.childNodes;
+          const textContent = filterNodes(childNodes, Node.TEXT_NODE)
+            .map(n => n.textContent);
+          assert.deepEqual(textContent, ['A', ' ', 'B']);
+        }
+      },
+      {
+        args: ['C', 'D'],
+        html: '<div>C\n  D</div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          const childNodes = dom.querySelector('div')!.childNodes;
+          const textContent = filterNodes(childNodes, Node.TEXT_NODE)
+            .map(n => n.textContent);
+          assert.deepEqual(textContent, ['C', ' ', 'D']);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart with trailing whitespace': {
+    render(x: any, y: any) {
+      return html`<div>${x} </div>`;
+    },
+    expectations: [
+      {
+        args: ['A'],
+        html: '<div>A\n  </div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          const childNodes = dom.querySelector('div')!.childNodes;
+          const textContent = filterNodes(childNodes, Node.TEXT_NODE)
+            .map(n => n.textContent);
+          assert.deepEqual(textContent, ['A', ' ']);
+        }
+      },
+      {
+        args: ['B'],
+        html: '<div>B\n  </div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          const childNodes = dom.querySelector('div')!.childNodes;
+          const textContent = filterNodes(childNodes, Node.TEXT_NODE)
+            .map(n => n.textContent);
+          assert.deepEqual(textContent, ['B', ' ']);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'AttributePart accepts a string': {
     render(x: any) {
       return html`<div class=${x}></div>`;
     },
@@ -88,7 +456,152 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div'],
   },
 
-  'two attribute expressions': {
+  'AttributePart accepts a number': {
+    render(x: any) {
+      return html`<div class=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [123],
+        html: '<div class="123"></div>'
+      },
+      {
+        args: [456.789],
+        html: '<div class="456.789"></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'AttributePart accepts undefined': {
+    render(x: any) {
+      return html`<div class=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [undefined],
+        html: '<div class="undefined"></div>'
+      },
+      {
+        args: ['TEST'],
+        html: '<div class="TEST"></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'AttributePart accepts null': {
+    render(x: any) {
+      return html`<div class=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [null],
+        html: '<div class="null"></div>'
+      },
+      {
+        args: ['TEST'],
+        html: '<div class="TEST"></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'AttributePart accepts noChange': {
+    // TODO: Test currently fails: `noChange` causes class="Object] [object"
+    // to be rendered; to be investigated
+    skip: true,
+    render(x: any) {
+      return html`<div class=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [noChange],
+        html: '<div class="undefined"></div>'
+      },
+      {
+        args: ['TEST'],
+        html: '<div class="TEST"></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'AttributePart accepts nothing': {
+    // TODO: Test currently fails: `nothing` causes unexpected DOM mutation on
+    // first render; to be investigated
+    skip: true,
+    render(x: any) {
+      return html`<div class=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [nothing],
+        html: '<div class="[object Object]"></div>'
+      },
+      {
+        args: ['TEST'],
+        html: '<div class="TEST"></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'AttributePart accepts a symbol': {
+    render(x: any) {
+      return html`<div class=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [Symbol()],
+        html: '<div class="Symbol()"></div>'
+      },
+      {
+        args: [Symbol()],
+        html: '<div class="Symbol()"></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'AttributePart accepts a symbol with description': {
+    render(x: any) {
+      return html`<div class=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [Symbol('description!')],
+        html: '<div class="Symbol(description!)"></div>'
+      },
+      {
+        args: [Symbol('description2!')],
+        html: '<div class="Symbol(description2!)"></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'AttributePart accepts an array': {
+    // TODO: Test currently fails: the default array.toString is being used
+    // during SSR, causing commas between values to be rendered. To be fixed.
+    skip: true,
+    render(x: any) {
+      return html`<div class=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [['a', 'b', 'c']],
+        html: '<div class="abc"></div>'
+      },
+      {
+        args: [['d', 'e', 'f']],
+        html: '<div class="def"></div>'
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'multiple AttributeParts on same node': {
     render(x: any, y: any) {
       return html`<div class=${x} foo=${y}></div>`;
     },
@@ -105,7 +618,7 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div'],
   },
 
-  'two expressions in same attribute': {
+  'multiple AttributeParts in same attribute': {
     render(x: any, y: any) {
       return html`<div class="${x} ${y}"></div>`;
     },
@@ -122,7 +635,7 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div'],
   },
 
-  'mix of expressions across multiple attributes': {
+  'multiple AttributeParts across multiple attributes': {
     render(a: any, b: any, c: any, d: any, e: any, f: any) {
       return html`<div ab="${a} ${b}" x c="${c}" y de="${d} ${e}" f="${f}" z></div>`;
     },
@@ -139,7 +652,30 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div'],
   },
 
-  'property expression': {
+  'PropertyPart accepts a string': {
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: ['foo'],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 'foo');
+        }
+      },
+      {
+        args: ['foo2'],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 'foo2');
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'PropertyPart accepts a number': {
     render(x: any) {
       return html`<div .foo=${x}></div>`;
     },
@@ -162,7 +698,219 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div'],
   },
 
-  'two property expression': {
+  'PropertyPart accepts a boolean': {
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [false],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, false);
+        }
+      },
+      {
+        args: [true],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, true);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'PropertyPart accepts undefined': {
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [undefined],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, undefined);
+        }
+      },
+      {
+        args: [1],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 1);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'PropertyPart accepts null': {
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [null],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, null);
+        }
+      },
+      {
+        args: [1],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 1);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'PropertyPart accepts noChange': {
+    // TODO: Test currently fails: SSR does not currently accept noChange in 
+    // property position. To fix.
+    skip: true,
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [noChange],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.notProperty((dom.querySelector('div'), 'foo');
+        }
+      },
+      {
+        args: [1],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 1);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'PropertyPart accepts nothing': {
+    // TODO: the current client-side does nothing special with `nothing`, just
+    // passes it on to the property; is that what we want?
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [nothing],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, nothing);
+        }
+      },
+      {
+        args: [1],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 1);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'PropertyPart accepts a symbol': {
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [testSymbol],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, testSymbol);
+        }
+      },
+      {
+        args: [1],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 1);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'PropertyPart accepts an object': {
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [testObject],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, testObject);
+        }
+      },
+      {
+        args: [1],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 1);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'PropertyPart accepts an array': {
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [testArray],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, testArray);
+        }
+      },
+      {
+        args: [1],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 1);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'PropertyPart accepts a function': {
+    render(x: any) {
+      return html`<div .foo=${x}></div>`;
+    },
+    expectations: [
+      {
+        args: [testFunction],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, testFunction);
+        }
+      },
+      {
+        args: [1],
+        html: '<div></div>',
+        check(assert: Chai.Assert, dom: HTMLElement) {
+          assert.strictEqual((dom.querySelector('div') as any).foo, 1);
+        }
+      }
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'multiple PropertyParts on same node': {
     render(x: any, y: any) {
       return html`<div .foo=${x} .bar=${y}></div>`;
     },
@@ -187,7 +935,7 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div'],
   },
 
-  'two expressions in one property': {
+  'multiple PropertyParts in one property': {
     render(x: any, y: any) {
       return html`<div .foo="${x},${y}"></div>`;
     },
@@ -210,7 +958,7 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div'],
   },
 
-  'event binding': {
+  'EventPart': {
     render(listener: (e: Event) => void) {
       return html`<button @click=${listener}>X</button>`;
     },
@@ -237,7 +985,7 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['button'],
   },
 
-  'boolean attribute binding, initially true': {
+  'BooleanAttributePart, initially true': {
     render(hide: boolean) {
       return html`<div ?hidden=${hide}></div>`;
     },
@@ -254,111 +1002,4 @@ export const tests: {[name: string] : SSRTest} = {
     stableSelectors: ['div'],
   },
 
-  'array with strings': {
-    render(words: string[]) {
-      return html`<div>${words}</div>`;
-    },
-    expectations: [
-      {
-        args: [['A', 'B', 'C']],
-        html: '<div>A\n  B\n  C</div>'
-      },
-      {
-        args: [['D', 'E', 'F']],
-        html: '<div>D\n  E\n  F</div>'
-      }
-    ],
-    stableSelectors: ['div'],
-  },
-
-  'array with strings, updated with fewer items': {
-    render(words: string[]) {
-     return html`<div>${words}</div>`;
-    },
-    expectations: [
-      {
-        args: [['A', 'B', 'C']],
-        html: '<div>A\n  B\n  C</div>'
-      },
-      // Attribute hydration not working yet
-      {
-        args: [['D', 'E']],
-        html: '<div>D\n  E</div>'
-      }
-    ],
-    stableSelectors: ['div'],
-  },
-
-  'array with strings, updated with more items': {
-    render(words: string[]) {
-      return html`<div>${words}</div>`;
-    },
-    expectations: [
-      {
-        args: [['A', 'B', 'C']],
-        html: '<div>A\n  B\n  C</div>'
-      },
-      // Attribute hydration not working yet
-      {
-        args: [['D', 'E', 'F', 'G']],
-        html: '<div>D\n  E\n  F\n  G</div>'
-      }
-    ],
-    stableSelectors: ['div'],
-  },
-
-  'array with templates': {
-    render(words: string[]) {
-      return html`<ol>${words.map((w) => html`<li>${w}</li>`)}</ol>`;
-    },
-    expectations: [
-      {
-        args: [['A', 'B', 'C']],
-        html: '<ol><li>A</li>\n  <li>B</li>\n  <li>C</li></ol>'
-      },
-      {
-        args: [['D', 'E', 'F']],
-        html: '<ol><li>D</li>\n  <li>E</li>\n  <li>F</li></ol>'
-      }
-    ],
-    stableSelectors: ['ol', 'li'],
-  },
-
-  'repeat with strings': {
-    skip: true,
-    render(words: string[]) {
-      return html`${repeat(words, (word, i) => `(${i} ${word})`)}`;
-    },
-    expectations: [
-      {
-        args: [['foo', 'bar', 'qux']],
-        html: '(0 foo)\n(1 bar)\n(2 qux)'
-      },
-      // Attribute hydration not working yet
-      {
-        args: [['A', 'B', 'C']],
-        html: '(0 A)(1 B)(2 C)'
-      }
-    ],
-    stableSelectors: [],
-  },
-
-  'repeat with templates': {
-    skip: true,
-    render(words: string[]) {
-      return html`${repeat(words, (word, i) => html`<p>${i}) ${word}</p>`)}`;
-    },
-    expectations: [
-      {
-        args: [['foo', 'bar', 'qux']],
-        html: '<p>0) foo</p><p>1) bar</p><p>2) qux</p>'
-      },
-      // Attribute hydration not working yet
-      {
-        args: [['A', 'B', 'C']],
-        html: '<p>0) A</p><p>1) B</p><p>2) C</p>'
-      }
-    ],
-    stableSelectors: ['p'],
-  },
 };

--- a/src/test/integration/tests/ssr-test.ts
+++ b/src/test/integration/tests/ssr-test.ts
@@ -36,6 +36,7 @@ export interface SSRTest {
    * Used to assert that the DOM reused in hydration, not recreated.
    */
   stableSelectors: Array<string>;
+  expectMutationsOnFirstRender?: boolean,
   skip?: boolean;
   only?: boolean;
 }


### PR DESCRIPTION
Sorry I reordered the tests a bit to collate by part type (and tried to normalize test naming), so diff is a little ugly.

Also includes #36/#38 multiple attribute test.

There are a few skipped tests added w/TODOs (all are probably straightforward, just ran out of time today, so can add to this PR or do separately):
* `NodePart accepts an element`: can't document.createElement an element on server
* `AttributePart accepts noChange`: Test currently fails: `noChange` causes `class="Object] [object"` to be rendered; to be investigated
* `AttributePart accepts nothing`: Test currently fails: `nothing` causes unexpected DOM mutation on first render; to be investigated
* `AttributePart accepts an array`: Test currently fails: the default array.toString is being used during SSR, causing commas between values to be rendered. To be fixed.
* `PropertyPart accepts noChange`: Test currently fails: SSR does not currently accept noChange in property position. To fix.

Also:
* `PropertyPart accepts nothing`: This is passing; the current client-side does nothing special with `nothing`, just passes it on to the property; is that what we want?

FWIW, made a jsBin to smoke test what lit-html does on the client with all the different value types for each part type: https://jsbin.com/qakixog/edit?html,output