### PR TITLE
Add integration test --debug option & launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "runtimeVersion": "13.12.0",
+      "request": "launch",
+      "name": "Test: Integration",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/test/integration/test.js",
+      "args": ["--debug"],
+      "outFiles": [
+        "${workspaceFolder}/./**/*.js"
+      ],
+      "runtimeArgs": ["--experimental-vm-modules"],
+    },
+    {
+      "type": "node",
+      "runtimeVersion": "13.12.0",
+      "request": "launch",
+      "name": "Demo Server",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/demo/server.js",
+      "outFiles": [
+        "${workspaceFolder}/./**/*.js"
+      ],
+      "runtimeArgs": ["--experimental-vm-modules"]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1673,6 +1673,11 @@
         "@types/chai": "*"
       }
     },
+    "@types/command-line-args": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
+      "integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg=="
+    },
     "@types/connect": {
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
@@ -1998,8 +2003,7 @@
     "array-back": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
@@ -2544,7 +2548,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
       "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-      "dev": true,
       "requires": {
         "array-back": "^3.0.1",
         "find-replace": "^3.0.0",
@@ -3238,7 +3241,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
       "requires": {
         "array-back": "^3.0.1"
       }
@@ -4303,8 +4305,7 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -6098,8 +6099,7 @@
     "typical": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "uglify-js": {
       "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "BSD-3-Clause",
   "repository": "PolymerLabs/lit-ssr",
   "devDependencies": {
+    "@types/command-line-args": "^5.0.0",
     "@koa/router": "^8.0.8",
     "@open-wc/testing": "^2.5.8",
     "@open-wc/testing-karma": "^3.3.10",
@@ -29,6 +30,7 @@
     "@types/resolve": "^1.14.0",
     "@types/tape-promise": "^4.0.0",
     "chai": "^4.2.0",
+    "command-line-args": "^5.1.1",
     "deepmerge": "^4.2.2",
     "karma": "^4.4.1",
     "karma-chai": "^0.1.0",

--- a/src/test/integration/server/server.ts
+++ b/src/test/integration/server/server.ts
@@ -34,7 +34,6 @@ export const startServer = async (port = 9090) => {
   router.get('/test/:suite/:test', async (context) => {
     const suiteName = context.params.suite;
     const testName = context.params.test;
-    console.debug('TEST', suiteName, testName);
 
     const {namespace} = await importModule(`../tests/${suiteName}-ssr.js`, import.meta.url, window);
     const module = namespace as typeof testModule;

--- a/src/test/integration/test.ts
+++ b/src/test/integration/test.ts
@@ -17,6 +17,19 @@ import testingKarma from '@open-wc/testing-karma';
 import deepmerge from 'deepmerge';
 
 import {startServer} from './server/server.js';
+import cliArgs from 'command-line-args';
+
+const options = [
+  {
+    name: 'debug',
+    type: Boolean,
+    alias: 'd',
+    description: 'Opens a Chrome window and runs karma in debug mode',
+    defaultValue: false
+  },
+];
+
+const args = cliArgs(options);
 
 const {Server} = karma;
 const {createDefaultConfig} = testingKarma;
@@ -47,6 +60,11 @@ const config: karma.ConfigOptions = deepmerge(createDefaultConfig({}), {
     preserveSymlinks: true,
   },
 } as any);
+
+if (args.debug) {
+  config.browsers = ['Chrome'];
+  config.singleRun = false;
+}
 
 (async () => {
   const ssrServer = await startServer();


### PR DESCRIPTION
The following will run integration tests in a Chrome window with Karma in debug mode rather than in Chrome headless:
```
npm run test:integration -- --debug
```

The added `launch.json` allows for nodejs debugging of both the `Demo Server` and `Integration Tests` in VSCode (integration tests are opened with above `--debug` flag).  These should be available under the "Run" pane on the left in VSCode (triangle with bug).