### PR TITLE
Add basic LitElement tests

### DIFF
--- a/src/test/integration/client/basic_test.ts
+++ b/src/test/integration/client/basic_test.ts
@@ -48,7 +48,7 @@ const assert = chai.assert;
  * html: {
  *   root: '<my-el></my-el>',
  *   'my-el': {
- *     root: '<span></span>'
+ *     root: '<my-el2></my-el2>'
  *     'my-el2': '<input>'
  *   },
  * 

--- a/src/test/integration/client/basic_test.ts
+++ b/src/test/integration/client/basic_test.ts
@@ -17,8 +17,78 @@ import '@open-wc/testing';
 import {tests} from '../tests/basic.js';
 import {render} from 'lit-html';
 import {hydrate} from 'lit-html/lib/hydrate.js';
+import {hydrateShadowRoots} from 'template-shadowroot/template-shadowroot.js';
+import {SSRExpectedHTML} from '../tests/ssr-test.js';
+import {LitElement} from 'lit-element';
+
+LitElement.hydrate = hydrate;
 
 const assert = chai.assert;
+
+/**
+ * Checks a tree of expected HTML against the DOM; the expected HTML can either
+ * be a string or an object containing keys of querySelector queries mapped to
+ * HTML expectations for the shadow root of the returned element(s); if more
+ * than one element is returned from the querySelector, the value must be an
+ * array of HTML expectations. When using in tree mode, the string 'root' is
+ * used as a sentinel to test the container at a given level.
+ * 
+ * Examples:
+ * 
+ * // Test `container` html
+ * html: '<div></div>'
+ * 
+ * // Test `container` and shadowRoot of `my-el`
+ * html: {
+ *   root: '<my-el></my-el>',
+ *   'my-el': '<span></span>',
+ * 
+ * // Test `container` and shadowRoot of `my-el`, and shadow root of my-el2
+ * inside of it
+ * html: {
+ *   root: '<my-el></my-el>',
+ *   'my-el': {
+ *     root: '<span></span>'
+ *     'my-el2': '<input>'
+ *   },
+ * 
+ * // Test `container` and shadowRoot series of `my-el`
+ * html: {
+ *   root: `
+ *      <my-el></my-el>
+ *      <my-el></my-el>`,
+ *   'my-el': [
+ *     '<div></div>',
+ *     '<div></div>'
+ *   ],
+*/
+const assertHTML = (container: Element | ShadowRoot, html: SSRExpectedHTML): void => {
+  if (typeof html !== 'object') {
+    assert.lightDom.equal(container, html);
+  } else {
+    for (const query in html) {
+      const subHtml = html[query];
+      if (query === 'root') {
+        assert.typeOf(subHtml, 'string', `html expectation for ':root' must be a string.`);
+        assert.lightDom.equal(container, subHtml as string);
+      } else {
+        const subContainers = Array.from(container.querySelectorAll(query))
+        ;
+        if (Array.isArray(subHtml)) {
+          assert.strictEqual(subContainers.length, subHtml.length, `Did not find expected number of elements for query '${query}'`);
+          subContainers.forEach((subContainer, i) => {
+            assert.instanceOf(subContainer.shadowRoot, ShadowRoot, `No shadowRoot for queried element '${query}[${i}]'`);
+            assertHTML(subContainer.shadowRoot!, subHtml[i]);
+          });
+        } else {
+          assert.strictEqual(subContainers.length, 1, `Number of nodes found for element query '${query}'`);
+          assert.instanceOf(subContainers[0].shadowRoot, ShadowRoot, `No shadowRoot for queried element '${query}'`);
+          assertHTML(subContainers[0].shadowRoot!, subHtml);
+        }
+      }
+    }
+  }
+}
 
 suite('basic', () => {
   let container: HTMLElement;
@@ -35,25 +105,38 @@ suite('basic', () => {
     return _mutations;
   };
 
-  setup(() => {
-    container = document.createElement('div');
-    _mutations = [];
-    observer = new MutationObserver((records) => {
-      _mutations.push(...records);
-    });
-    clearMutations();
+  const observeMutations = (container: Element) => {
     observer.observe(container, {
       attributes: true,
       characterData: true,
       childList: true,
       subtree: true,
     });
+    // Deeply observe all roots
+    Array.from(container.querySelectorAll('*'))
+      .filter(el => el.shadowRoot)
+      .forEach(el => observeMutations(el));
+  }
+
+  setup(() => {
+    // Container is appended to body so that CE upgrades run
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    _mutations = [];
+    observer = new MutationObserver((records) => {
+      _mutations.push(...records);
+    });
+    clearMutations();
+  });
+
+  teardown(() => {
+    document.body.removeChild(container);
   });
 
 
   for (const [testName, testDescOrFn] of Object.entries(tests)) {
     let testSetup = (typeof testDescOrFn === 'function') ? testDescOrFn() : testDescOrFn;
-    const {render: testRender, expectations, stableSelectors, expectMutationsOnFirstRender, expectMutationsDuringHydration} = testSetup;
+    const {render: testRender, registerElements, expectations, stableSelectors, expectMutationsOnFirstRender, expectMutationsDuringHydration, expectMutationsDuringUpgrade} = testSetup;
 
     const testFn = testSetup.skip ? test.skip : testSetup.only ? test.only : test;
 
@@ -63,16 +146,33 @@ suite('basic', () => {
       const response = await fetch(`/test/basic/${testName}`);
       container.innerHTML = await response.text();
 
+      // For element tests, hydrate shadowRoots
+      if (typeof registerElements === 'function') {
+        hydrateShadowRoots(container);
+      }
+
+      // Start watching for mutations (deeply into any shadowRoots)
+      observeMutations(container);
+
       // The first expectation args are used in the server render. Check the DOM
       // pre-hydration to make sure they're correct. The DOM is changed again
       // against the first expectation after hydration in the loop below.
-      assert.lightDom.equal(container, expectations[0].html);
+      assertHTML(container, expectations[0].html);
       const stableNodes = stableSelectors.map(
           (selector) => container.querySelector(selector));
       clearMutations();
 
+      // For element tests, register & upgrade/hydrate elements
+      if (typeof registerElements === 'function') {
+        await registerElements();
+        assertHTML(container, expectations[0].html);
+        if (!expectMutationsDuringUpgrade) {
+          assert.isEmpty(getMutations(), 'Upgrading elements should cause no DOM mutations');
+        }
+      }
+
       let i = 0;
-      for (const {args, html, check} of expectations) {
+      for (const {args, html, setup, check} of expectations) {
         if (i === 0) {
           hydrate(testRender(...args), container);
           // Hydration should cause no DOM mutations, because it does not
@@ -81,36 +181,44 @@ suite('basic', () => {
             assert.isEmpty(getMutations(), 'Hydration should cause no DOM mutations');
           }
           clearMutations();
+        }
 
-          // After hydration, render() will be operable.
-          render(testRender(...args), container);
+        // Custom setup callback
+        if (setup !== undefined) {
+          const ret = setup(assert, container);
+          // Avoid introducing microtasks unless setup function was async
+          if (ret && (ret as any).then) {
+            await ret;
+          }
+        }
+        // After hydration, render() will be operable.
+        render(testRender(...args), container);
+
+        if (i === 0) {
           // The first render should also cause no mutations, since it's using
           // the same data as the server.
           if (!expectMutationsOnFirstRender) {
             assert.isEmpty(getMutations(), 'First render should cause no DOM mutations');
           }
-        } else {
-          render(testRender(...args), container);
         }
 
-        // Check the markup
-        assert.lightDom.equal(container, html);
+        // Custom check before HTML assertion, so it can await el.updateComplete
+        if (check !== undefined) {
+          const ret = check(assert, container);
+          // Avoid introducing microtasks unless check function was async
+          if (ret && (ret as any).then) {
+            await ret;
+          }
+        }
 
         // Check that stable nodes didn't change
         const checkNodes = stableSelectors.map(
             (selector) => container.querySelector(selector));
         assert.deepEqual(stableNodes, checkNodes);
 
-        // Custom check
-        if (check !== undefined) {
-          const ret = check(assert, container);
-          // Avoid introducing microtasks unless check function was
-          // explicitly async, since rendering is synchronous and generally
-          // we should be checking the rendering synchronously
-          if (ret && (ret as any).then) {
-            await ret;
-          }
-        }
+        // Check the markup
+        assertHTML(container, html);
+
         i++;
       }
     });

--- a/src/test/integration/server/server.ts
+++ b/src/test/integration/server/server.ts
@@ -41,6 +41,9 @@ export const startServer = async (port = 9090) => {
     const testDescOrFn = module.tests[testName] as SSRTest;
     const test = (typeof testDescOrFn === 'function') ? testDescOrFn() : testDescOrFn;
     const {render} = module;
+    if (test.registerElements) {
+      await test.registerElements();
+    }
     // For debugging:
     if (false) {
       const result = render(test.render(...test.expectations[0].args));

--- a/src/test/integration/tests/basic.ts
+++ b/src/test/integration/tests/basic.ts
@@ -1444,7 +1444,7 @@ export const tests: {[name: string] : SSRTest} = {
   'PropertyPart accepts noChange (reflected)': {
     // TODO: Right now, SSR just reflects the raw value noChange, so it gets
     // '[object Object]' in the HTML, but when hydration runes, the committer
-    // sets 'undefined' (which gets reflectd), so there's no way to write a
+    // sets 'undefined' (which gets reflected), so there's no way to write a
     // correct test; we should either fix the client-side to not set
     // `undefined`, or else just serialize 'undefined' for noChange on the server
     skip: true,
@@ -3278,6 +3278,7 @@ export const tests: {[name: string] : SSRTest} = {
       // TODO: lit-element-renderer does not yet support reflected properties;
       // should the renderer call into `addPropertiesForElement`? The first time
       // a renderer is created for a given element type?
+      // https://github.com/PolymerLabs/lit-ssr/issues/61
       skip: true,
       registerElements() {
         class LEReflectedBinding extends LitElement {

--- a/src/test/integration/tests/basic.ts
+++ b/src/test/integration/tests/basic.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {html, noChange, nothing, directive, Part} from 'lit-html';
+import {html, noChange, nothing, directive, Part, TemplateResult} from 'lit-html';
 import {repeat} from 'lit-html/directives/repeat.js';
 import {guard} from 'lit-html/directives/guard.js';
 import {cache} from 'lit-html/directives/cache.js';
@@ -25,6 +25,8 @@ import {TestAsyncIterable} from 'lit-html/test/lib/test-async-iterable.js';
 import {ifDefined} from 'lit-html/directives/if-defined.js';
 import {live} from 'lit-html/directives/live.js';
 
+import { LitElement, property } from 'lit-element';
+import {renderLight} from 'lit-element/lib/render-light.js';
 
 import { SSRTest } from './ssr-test';
 
@@ -548,13 +550,12 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise, 'foo'],
           html: '<div>foo</div>',
-          async check() {
-            // Setup next render
+        },
+        {
+          async setup() {
             resolve('promise');
             await promise;
           },
-        },
-        {
           args: [promise, 'foo'],
           html: '<div>promise</div>',
         },
@@ -576,22 +577,20 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise2, promise1],
           html: '<div></div>',
-          async check() {
-            // Setup next render
+        },
+        {
+          async setup() {
             resolve1('promise1');
             await promise1;
           },
-        },
-        {
           args: [promise2, promise1],
           html: '<div>promise1</div>',
-          async check() {
-            // Setup next render
+        },
+        {
+          async setup() {
             resolve2('promise2');
             await promise2;
           },
-        },
-        {
           args: [promise2, promise1],
           html: '<div>promise2</div>',
         },
@@ -610,20 +609,18 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [iterable],
           html: '<div></div>',
-          check: async () => {
-            // Setup the next render
-            await iterable.push('a');
-          }
         },
         {
+          async setup() {
+            await iterable.push('a');
+          },
           args: [iterable],
           html: '<div>a</div>',
-          check: async () => {
-            // Setup the next render
-            await iterable.push('b');
-          }
         },
         {
+          async setup() {
+            await iterable.push('b');
+          },
           args: [iterable],
           html: '<div>\n  a\n  b\n</div>',
         },
@@ -642,20 +639,18 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [iterable],
           html: '<div></div>',
-          check: async () => {
-            // Setup the next render
-            await iterable.push('a');
-          }
         },
         {
+          async setup() {
+            await iterable.push('a');
+          },
           args: [iterable],
           html: '<div>a</div>',
-          check: async () => {
-            // Setup the next render
-            await iterable.push('b');
-          }
         },
         {
+          async setup() {
+            await iterable.push('b');
+          },
           args: [iterable],
           html: '<div>b</div>',
         },
@@ -1004,13 +999,12 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise, 'foo'],
           html: '<div attr="foo"></div>',
-          async check() {
-            // Setup next render
-            resolve('promise');
-            await promise;
-          }
         },
         {
+          async setup() {
+            resolve('promise');
+            await promise;
+          },
           args: [promise, 'foo'],
           html: '<div attr="promise"></div>',
         },
@@ -1035,22 +1029,20 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise2, promise1],
           html: '<div></div>',
-          async check() {
-            // Setup next render
+        },
+        {
+          async setup() {
             resolve1('promise1');
             await promise1;
           },
-        },
-        {
           args: [promise2, promise1],
           html: '<div attr="promise1"></div>',
-          async check() {
-            // Setup next render
+        },
+        {
+          async setup() {
             resolve2('promise2');
             await promise2;
           },
-        },
-        {
           args: [promise2, promise1],
           html: '<div attr="promise2"></div>',
         },
@@ -1940,14 +1932,15 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise, 'foo'],
           html: '<div></div>',
-          async check(assert: Chai.Assert, dom: HTMLElement) {
+          check(assert: Chai.Assert, dom: HTMLElement) {
             assert.strictEqual((dom.querySelector('div') as any).prop, 'foo');
-            // Setup next render
-            resolve('promise');
-            await promise;
           }
         },
         {
+          async setup() {
+            resolve('promise');
+            await promise;
+          },
           args: [promise, 'foo'],
           html: '<div></div>',
           check(assert: Chai.Assert, dom: HTMLElement) {
@@ -1973,15 +1966,16 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise, 'foo'],
           html: '<div class="foo"></div>',
-          async check(assert: Chai.Assert, dom: HTMLElement) {
+          check(assert: Chai.Assert, dom: HTMLElement) {
             // Note className coerces to string
             assert.strictEqual(dom.querySelector('div')!.className, 'foo');
-            // Setup next render
-            resolve('promise');
-            await promise;
           }
         },
         {
+          async setup() {
+            resolve('promise');
+            await promise;
+          },
           args: [promise, 'foo'],
           html: '<div class="promise"></div>',
           check(assert: Chai.Assert, dom: HTMLElement) {
@@ -2014,24 +2008,26 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise2, promise1],
           html: '<div></div>',
-          async check(assert: Chai.Assert, dom: HTMLElement) {
+          check(assert: Chai.Assert, dom: HTMLElement) {
             assert.notProperty((dom.querySelector('div') as any), 'prop');
-            // Setup next render
+          }
+        },
+        {
+          async setup() {
             resolve1('promise1');
             await promise1;
-          }
-        },
-        {
+          },
           args: [promise2, promise1],
           html: '<div></div>',
-          async check(assert: Chai.Assert, dom: HTMLElement) {
+          check(assert: Chai.Assert, dom: HTMLElement) {
             assert.strictEqual((dom.querySelector('div') as any).prop, 'promise1');
-            // Setup next render
-            resolve2('promise2');
-            await promise2;
           }
         },
         {
+          async setup() {
+            resolve2('promise2');
+            await promise2;
+          },
           args: [promise2, promise1],
           html: '<div></div>',
           check(assert: Chai.Assert, dom: HTMLElement) {
@@ -2056,26 +2052,28 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise2, promise1],
           html: '<div></div>',
-          async check(assert: Chai.Assert, dom: HTMLElement) {
+          check(assert: Chai.Assert, dom: HTMLElement) {
             // Note className coerces to string
             assert.strictEqual(dom.querySelector('div')!.className, '');
-            // Setup next render
+          }
+        },
+        {
+          async setup() {
             resolve1('promise1');
             await promise1;
-          }
-        },
-        {
+          },
           args: [promise2, promise1],
           html: '<div class="promise1"></div>',
-          async check(assert: Chai.Assert, dom: HTMLElement) {
+          check(assert: Chai.Assert, dom: HTMLElement) {
             // Note className coerces to string
             assert.strictEqual(dom.querySelector('div')!.className, 'promise1');
-            // Setup next render
-            resolve2('promise2');
-            await promise2;
           }
         },
         {
+          async setup() {
+            resolve2('promise2');
+            await promise2;
+          },
           args: [promise2, promise1],
           html: '<div class="promise2"></div>',
           check(assert: Chai.Assert, dom: HTMLElement) {
@@ -2410,16 +2408,17 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise, listener1],
           html: '<button>X</button>',
-          async check(assert: Chai.Assert, dom: HTMLElement) {
+          check(assert: Chai.Assert, dom: HTMLElement) {
             const button = dom.querySelector('button')!;
             button.click();
             assert.strictEqual((button as any).__wasClicked1, true, 'not clicked during first render');
-            // Setup next render
-            resolve(listener2);
-            await promise;
           }
         },
         {
+          async setup() {
+            resolve(listener2);
+            await promise;
+          },
           args: [promise, listener1],
           html: '<button>X</button>',
           check(assert: Chai.Assert, dom: HTMLElement) {
@@ -2448,29 +2447,31 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise2, promise1],
           html: '<button>X</button>',
-          async check(assert: Chai.Assert, dom: HTMLElement) {
+          check(assert: Chai.Assert, dom: HTMLElement) {
             assert.notProperty((dom.querySelector('button') as any), 'prop');
             const button = dom.querySelector('button')!;
             button.click();
             assert.notProperty(button, '__wasClicked1', 'was clicked during first render');
-            // Setup next render
-            resolve1(listener1);
-            await promise1;
           }
         },
         {
+          async setup() {
+            resolve1(listener1);
+            await promise1;
+          },
           args: [promise2, promise1],
           html: '<button>X</button>',
-          async check(assert: Chai.Assert, dom: HTMLElement) {
+          check(assert: Chai.Assert, dom: HTMLElement) {
             const button = dom.querySelector('button')!;
             button.click();
             assert.strictEqual((button as any).__wasClicked1, true, 'not clicked during second render');
-            // Setup next render
-            resolve2(listener2);
-            await promise2;
           }
         },
         {
+          async setup() {
+            resolve2(listener2);
+            await promise2;
+          },
           args: [promise2, promise1],
           html: '<button>X</button>',
           check(assert: Chai.Assert, dom: HTMLElement) {
@@ -2768,13 +2769,12 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise, true],
           html: '<div hidden></div>',
-          async check() {
-            // Setup next render
-            resolve(false);
-            await promise;
-          }
         },
         {
+          async setup() {
+            resolve(false);
+            await promise;
+          },
           args: [promise, true],
           html: '<div></div>',
         },
@@ -2799,22 +2799,20 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: [promise2, promise1],
           html: '<div></div>',
-          async check() {
-            // Setup next render
+        },
+        {
+          async setup() {
             resolve1(true);
             await promise1;
-          }
-        },
-        {
+          },
           args: [promise2, promise1],
           html: '<div hidden></div>',
-          async check() {
-            // Setup next render
-            resolve2(false);
-            await promise2;
-          }
         },
         {
+          async setup() {
+            resolve2(false);
+            await promise2;
+          },
           args: [promise2, promise1],
           html: '<div></div>',
         },
@@ -3166,5 +3164,296 @@ export const tests: {[name: string] : SSRTest} = {
       ],
       stableSelectors: ['div', 'span'],
     }
-  }
+  },
+
+  /******************************************************
+   * LitElement tests
+   ******************************************************/
+
+  'LitElement: Basic': () => {
+    return {
+      registerElements() {
+        customElements.define('le-basic', class extends LitElement {
+          render() {
+            return html` <div>[le-basic: <slot></slot>]</div>`;
+          }
+        });
+      },
+      render(x: string) {
+        return html`<le-basic>${x}</le-basic>`;
+      },
+      expectations: [
+        {
+          args: ['x'],
+          html: {
+            root: `<le-basic>x</le-basic>`,
+            'le-basic': `<div>[le-basic: <slot></slot>]</div>`
+          },
+        },
+      ],
+      stableSelectors: ['le-basic'],
+    };
+  },
+
+  'LitElement: Nested': () => {
+    return {
+      registerElements() {
+        customElements.define('le-nested1', class extends LitElement {
+          render() {
+            return html` <div>[le-nested1: <le-nested2><slot></slot></le-nested2>]</div>`;
+          }
+        });
+        customElements.define('le-nested2', class extends LitElement {
+          render() {
+            return html` <div>[le-nested2: <slot></slot>]</div>`;
+          }
+        });
+      },
+      render(x: string) {
+        return html`<le-nested1>${x}</le-nested1>`;
+      },
+      expectations: [
+        {
+          args: ['x'],
+          html: {
+            root: `<le-nested1>x</le-nested1>`,
+            'le-nested1': {
+              root: `<div>[le-nested1: <le-nested2><slot></slot></le-nested2>]</div>`,
+              'le-nested2': `<div>[le-nested2: <slot></slot>]</div>`
+            }
+          },
+        },
+      ],
+      stableSelectors: ['le-nested1'],
+    };
+  },
+
+  'LitElement: Property binding': () => {
+    return {
+      registerElements() {
+        class LEPropBinding extends LitElement {
+          @property()
+          prop = 'default';
+          render() {
+            return html` <div>[${this.prop}]</div>`;
+          }
+        }
+        customElements.define('le-prop-binding', LEPropBinding);
+      },
+      render(prop: any) {
+        return html`<le-prop-binding .prop=${prop}></le-prop-binding>`;
+      },
+      expectations: [
+        {
+          args: ['boundProp1'],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-prop-binding')! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual((el as any).prop, 'boundProp1');
+          },
+          html: {
+            root: `<le-prop-binding></le-prop-binding>`,
+            'le-prop-binding': `<div>\n  [\n  boundProp1\n  ]\n</div>`
+          },
+        },
+        {
+          args: ['boundProp2'],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-prop-binding')! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual((el as any).prop, 'boundProp2');
+          },
+          html: {
+            root: `<le-prop-binding></le-prop-binding>`,
+            'le-prop-binding': `<div>\n  [\n  boundProp2\n  ]\n</div>`
+          },
+        },
+      ],
+      stableSelectors: ['le-prop-binding'],
+    };
+  },
+
+  'LitElement: Reflected property binding': () => {
+    return {
+      // TODO: lit-element-renderer does not yet support reflected properties;
+      // should the renderer call into `addPropertiesForElement`? The first time
+      // a renderer is created for a given element type?
+      skip: true,
+      registerElements() {
+        class LEReflectedBinding extends LitElement {
+          @property({reflect: true})
+          prop = 'default';
+          render() {
+            return html` <div>[${this.prop}]</div>`;
+          }
+        }
+        customElements.define('le-reflected-binding', LEReflectedBinding);
+      },
+      render(prop: any) {
+        return html`<le-reflected-binding .prop=${prop}></le-reflected-binding>`;
+      },
+      expectations: [
+        {
+          args: ['boundProp1'],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-reflected-binding')! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual((el as any).prop, 'boundProp1');
+          },
+          html: {
+            root: `<le-reflected-binding prop="boundProp1"></le-reflected-binding>`,
+            'le-reflected-binding': `<div>\n  [\n  boundProp1\n  ]\n</div>`
+          },
+        },
+        {
+          args: ['boundProp2'],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-prop-binding')! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual((el as any).prop, 'boundProp2');
+          },
+          html: {
+            root: `<le-reflected-binding prop="boundProp2"></le-reflected-binding>`,
+            'le-reflected-binding': `<div>\n  [\n  boundProp2\n  ]\n</div>`
+          },
+        },
+      ],
+      stableSelectors: ['le-reflected-binding'],
+    };
+  },
+
+  'LitElement: Attribute binding': () => {
+    return {
+      registerElements() {
+        class LEAttrBinding extends LitElement {
+          @property()
+          prop = 'default';
+          render() {
+            return html` <div>[${this.prop}]</div>`;
+          }
+        }
+        customElements.define('le-attr-binding', LEAttrBinding);
+      },
+      render(prop: any) {
+        return html`<le-attr-binding prop=${prop}></le-attr-binding>`;
+      },
+      expectations: [
+        {
+          args: ['boundProp1'],
+          async check(_assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-attr-binding')! as LitElement;
+            await el.updateComplete;
+          },
+          html: {
+            root: `<le-attr-binding prop="boundProp1"></le-attr-binding>`,
+            'le-attr-binding': `<div>\n  [\n  boundProp1\n  ]\n</div>`
+          },
+        },
+        {
+          args: ['boundProp2'],
+          async check(_assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-attr-binding')! as LitElement;
+            await el.updateComplete;
+          },
+          html: {
+            root: `<le-attr-binding prop="boundProp2"></le-attr-binding>`,
+            'le-attr-binding': `<div>\n  [\n  boundProp2\n  ]\n</div>`
+          },
+        },
+      ],
+      stableSelectors: ['le-attr-binding'],
+    };
+  },
+
+  'LitElement: TemplateResult->Node binding': () => {
+    return {
+      registerElements() {
+        class LENodeBinding extends LitElement {
+          @property()
+          template: string | TemplateResult = 'default';
+          render() {
+            return html` <div>${this.template}</div>`;
+          }
+        }
+        customElements.define('le-node-binding', LENodeBinding);
+      },
+      render(template: (s: string) => TemplateResult) {
+        return html`<le-node-binding .template=${template('shadow')}>${template('light')}</le-node-binding>`;
+      },
+      expectations: [
+        {
+          args: [(s: string) => html`[template1: ${s}]`],
+          async check(_assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-node-binding')! as LitElement;
+            await el.updateComplete;
+          },
+          html: {
+            root: `<le-node-binding>\n  [template1:\n  light\n  ]\n</le-node-binding>`,
+            'le-node-binding': `<div>\n  [template1:\n  shadow\n  ]\n</div>`
+          },
+        },
+        {
+          args: [(s: string) => html`[template2: ${s}]`],
+          async check(_assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-node-binding')! as LitElement;
+            await el.updateComplete;
+          },
+          html: {
+            root: `<le-node-binding>\n  [template2:\n  light\n  ]\n</le-node-binding>`,
+            'le-node-binding': `<div>\n  [template2:\n  shadow\n  ]\n</div>`
+          },
+        },
+      ],
+      stableSelectors: ['le-node-binding'],
+    };
+  },
+
+  'LitElement: renderLight': () => {
+    return {
+      registerElements() {
+        class LERenderLight extends LitElement {
+          @property()
+          prop = 'default';
+          render() {
+            return html` <div>[shadow:${this.prop}<slot></slot>]</div>`;
+          }
+          renderLight() {
+            return html` <div>[light:${this.prop}]</div>`;
+          }
+        }
+        customElements.define('le-render-light', LERenderLight);
+      },
+      render(prop: any) {
+        return html`<le-render-light .prop=${prop}>${renderLight()}</le-render-light>`;
+      },
+      expectations: [
+        {
+          args: ['boundProp1'],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-render-light')! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual((el as any).prop, 'boundProp1');
+          },
+          html: {
+            root: `<le-render-light>\n  <div>\n    [light:\n    boundProp1\n    ]\n  </div>\n</le-render-light>`,
+            'le-render-light': `<div>\n  [shadow:\n  boundProp1\n  <slot></slot>\n  ]\n</div>`
+          },
+        },
+        {
+          args: ['boundProp2'],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector('le-render-light')! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual((el as any).prop, 'boundProp2');
+          },
+          html: {
+            root: `<le-render-light>\n  <div>\n    [light:\n    boundProp2\n    ]\n  </div>\n</le-render-light>`,
+            'le-render-light': `<div>\n  [shadow:\n  boundProp2\n  <slot></slot>\n  ]\n</div>`
+          },
+        },
+      ],
+      stableSelectors: ['le-render-light'],
+    };
+  },
+
 };

--- a/src/test/integration/tests/ssr-test.ts
+++ b/src/test/integration/tests/ssr-test.ts
@@ -14,6 +14,8 @@
 
 import { TemplateResult } from 'lit-html';
 
+export type SSRExpectedHTML = string | {[name: string] : SSRExpectedHTML | SSRExpectedHTML[]};
+
 export interface SSRTestDescription {
   render(...args: any): TemplateResult;
   expectations: Array<{
@@ -28,9 +30,11 @@ export interface SSRTestDescription {
      *
      * Does not need to contain lit-html marker comments.
      */
-    html: string;
+    html: SSRExpectedHTML;
 
+    setup?(assert: Chai.Assert, dom: HTMLElement): void | Promise<unknown>
     check?(assert: Chai.Assert, dom: HTMLElement): void | Promise<unknown>;
+
   }>;
   /**
    * A list of selectors of elements that should no change between renders.
@@ -39,8 +43,10 @@ export interface SSRTestDescription {
   stableSelectors: Array<string>;
   expectMutationsOnFirstRender?: boolean,
   expectMutationsDuringHydration?: boolean,
+  expectMutationsDuringUpgrade?: boolean,
   skip?: boolean;
   only?: boolean;
+  registerElements?() : void | Promise<unknown>;
 }
 
 export type SSRTestFactory = () => SSRTestDescription;


### PR DESCRIPTION
In addition:
* Adds deep mutation obseving
* Add ability for deep html expectations
* Adds setup() callback that runs before render
* Changes check() callback to run before the html expectation (to allow awaiting a promise before checking)

Related lit-element PR: https://github.com/Polymer/lit-element/pull/1021

Fixes #46 
FIxes #45 