### PR TITLE
Add test for vendor-prefixed properties in styleMap.

### DIFF
--- a/src/test/integration/tests/basic.ts
+++ b/src/test/integration/tests/basic.ts
@@ -897,12 +897,12 @@ export const tests: {[name: string] : SSRTest} = {
     },
     expectations: [
       {
-        args: [{background: 'red', paddingTop: '10px', '--my-prop': 'green'}],
-        html: '<div style="background: red; padding-top: 10px; --my-prop:green;"></div>'
+        args: [{background: 'red', paddingTop: '10px', '--my-prop': 'green', webkitAppearance: 'none'}],
+        html: '<div style="background: red; padding-top: 10px; --my-prop:green; -webkit-appearance: none;"></div>'
       },
       {
-        args: [{paddingTop: '20px', '--my-prop': 'gray', backgroundColor: 'white'}],
-        html: '<div style="padding-top: 20px; --my-prop:gray; background-color: white;"></div>'
+        args: [{paddingTop: '20px', '--my-prop': 'gray', backgroundColor: 'white', webkitAppearance: 'inherit'}],
+        html: '<div style="padding-top: 20px; --my-prop:gray; -webkit-appearance: inherit; background-color: white;"></div>'
       }
     ],
     // styleMap does not dirty check individual properties before setting,


### PR DESCRIPTION
Associated test to go along with `lit-html` side change to support SSR of vendor-prefixed properties in `styleMap`: https://github.com/Polymer/lit-html/pull/1166/commits/e1f062e30e68e14307ec6f680a62537ec2931bc1#diff-7279ba6d455ed844d391b54fb9b6cd63