### PR TITLE
Updates for integration with lit-ssr-hacker-news app

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
   "configurations": [
     {
       "type": "node",
-      "runtimeVersion": "13.12.0",
+      "runtimeVersion": "14.4.0",
       "request": "launch",
       "name": "Test: Integration (debug)",
       "skipFiles": [
@@ -21,7 +21,7 @@
     },
     {
       "type": "node",
-      "runtimeVersion": "13.12.0",
+      "runtimeVersion": "14.4.0",
       "request": "launch",
       "name": "Demo Server",
       "skipFiles": [

--- a/custom_typings/node.d.ts
+++ b/custom_typings/node.d.ts
@@ -7,18 +7,25 @@ declare global {
 }
 
 declare module 'vm' {
-  class SourceTextModule {
+
+  class Module {
+    dependencySpecifiers: ReadonlyArray<string>;
+    error?: any;
+    namespace: any;
     status: string;
     identifier: string;
-    namespace: any;
-    context: any;
-    error?: any;
-    dependencySpecifiers: ReadonlyArray<string>;
-
-    constructor(source: string, options: any);
-
-    link(linker: (specifier: string, referencingModule: SourceTextModule) => SourceTextModule | Promise<SourceTextModule>): Promise<void>;
-    instantiate(): void;
     evaluate(): Promise<{result: unknown}>;
+    link(linker: (specifier: string, referencingModule: Module) => Module | Promise<Module>): Promise<void>;
+  }
+
+  class SourceTextModule extends Module {
+    context: any;
+    constructor(source: string, options: any);
+    instantiate(): void;
+  }
+
+  class SyntheticModule extends Module {
+    constructor(exportNames: string[], evaluateCallback: (this: SyntheticModule) => void, options: any);
+    setExport(name: string, value: any);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1839,8 +1839,16 @@
     "@types/node": {
       "version": "13.7.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
-      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
-      "dev": true
+      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "@types/parse5": {
       "version": "5.0.2",
@@ -2064,8 +2072,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -2547,7 +2554,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2823,8 +2829,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -3301,6 +3306,16 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
+    },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fresh": {
       "version": "0.5.2",
@@ -4278,13 +4293,12 @@
       "version": "github:Polymer/lit-element#28d48989d15ac7243328f7aaf4be9113bc798504",
       "from": "github:Polymer/lit-element#hydration",
       "requires": {
-        "lit-html": "^1.2.0"
+        "lit-html": "lit-html@1.2.1"
       },
       "dependencies": {
         "lit-html": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
-          "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+          "version": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
+          "from": "lit-html@1.2.1"
         }
       }
     },
@@ -4636,8 +4650,7 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-releases": {
       "version": "1.1.52",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
+    "build:watch": "tsc --watch",
+    "build:lit-element:watch": "tsc --project node_modules/lit-element --watch",
     "start": "node --experimental-vm-modules ./demo/server.js",
     "test": "npm run test:unit && npm run test:integration",
     "test:integration": "node --experimental-vm-modules test/integration/test.js",
@@ -44,6 +46,7 @@
   "dependencies": {
     "@types/koa": "^2.0.49",
     "@types/koa-static": "^4.0.1",
+    "@types/node-fetch": "^2.5.7",
     "@types/tape": "^4.2.33",
     "@webcomponents/shadycss": "^1.9.1",
     "koa": "^2.7.0",
@@ -51,10 +54,11 @@
     "koa-static": "^5.0.0",
     "lit-element": "Polymer/lit-html#hydration-hydrate",
     "lit-html": "Polymer/lit-html#hydration",
-    "template-shadowroot": "webcomponents/template-shadowroot",
+    "node-fetch": "^2.6.0",
     "parse5": "^5.1.0",
     "resolve": "^1.10.1",
-    "tape": "^4.11.0"
+    "tape": "^4.11.0",
+    "template-shadowroot": "webcomponents/template-shadowroot"
   },
   "engines": {
     "node": ">=13.9.0"

--- a/src/lib/import-module.ts
+++ b/src/lib/import-module.ts
@@ -90,6 +90,8 @@ const initializeImportMeta = (meta: any, module: vm.SourceTextModule) => {
   meta.url = module.identifier;
 };
 
+let importId = 0;
+
 /**
  * Imports a module given by `path` into a new VM context with `sandbox` as the
  * global object.
@@ -142,7 +144,7 @@ export const importModule = async (
         initializeImportMeta,
         importModuleDynamically,
         context,
-        identifier: moduleURL.toString(),
+        identifier: moduleURL.toString() + `:${importId++}`,
       });
     })();
     moduleCache.set(modulePath, modulePromise);

--- a/src/lib/import-module.ts
+++ b/src/lib/import-module.ts
@@ -58,7 +58,7 @@ const resolveSpecifier = (specifier: string, referrer: string): URL => {
       return new URL(specifier, referrer);
     }
 
-    if (specifier.startsWith('lit-html')) {
+    if (specifier.startsWith('lit-html') || specifier.startsWith('lit-element')) {
       // Override where we resolve lit-html from so that we always resolve to
       // a single version of lit-html.
       referrer = import.meta.url;

--- a/src/lib/import-module.ts
+++ b/src/lib/import-module.ts
@@ -14,17 +14,18 @@
  */
 
 import * as path from 'path';
-import * as fs from 'fs';
+import {promises as fs} from 'fs';
 import {URL} from 'url';
 import * as vm from 'vm';
 import resolve from 'resolve';
-
-const {readFile} = fs.promises;
+import {builtinModules} from 'module';
 
 type PackageJSON = {main?: string; module?: string; 'jsnext:main'?: string};
 
 const isRelativeOrAbsolutePath = (s: string) =>
   s.match(/^(\.){0,2}\//) !== null;
+
+const builtIns = new Set(builtinModules);
 
 /**
  * Resolves specifiers using web-ish Node module resolution. Web-compatible
@@ -36,12 +37,6 @@ const isRelativeOrAbsolutePath = (s: string) =>
  * currently hard-coded, but should instead be done with a configuration object.
  */
 const resolveSpecifier = (specifier: string, referrer: string): URL => {
-  // console.log('resolveSpecifier', specifier, referrer);
-
-  // if (specifier.endsWith('render-light.js')) {
-  //   console.log('resolveSpecifier render-light.js', specifier, referrer);
-  // }
-
   if (referrer === undefined) {
     throw new Error('referrer is undefined');
   }
@@ -78,19 +73,16 @@ const resolveSpecifier = (specifier: string, referrer: string): URL => {
     });
     return new URL(`file:${modulePath}`);
   }
-  // if (specifier.endsWith('render-light.js')) {
-  //   console.log('  ', moduleURL.pathname);
-  // }
 };
 
 /**
  * Web-like import.meta initializer that sets up import.meta.url
  */
-const initializeImportMeta = (meta: any, module: vm.SourceTextModule) => {
+const initializeImportMeta = (meta: any, module: vm.Module) => {
   meta.url = module.identifier;
 };
 
-let importId = 0;
+let vmContextId = 0;
 
 /**
  * Imports a module given by `path` into a new VM context with `sandbox` as the
@@ -108,17 +100,18 @@ export const importModule = async (
   // TODO: maybe move this call outside this function and share across requests.
   // Only if we can freeze all globals though.
   const context = vm.createContext(sandbox);
+  vmContextId++;
 
   // TODO: consider a multi-level cache with one cache shared across requests.
   // We could mark some modules as safe for reuse, like lit-html & lit-element.
   // Only possible if we can freeze and reuse the global as needed for the
   // above TODO as well. Even then, any object shared across requests could be a
   // potential source of cross-request leaks.
-  const moduleCache = new Map<string, Promise<vm.SourceTextModule>>();
+  const moduleCache = new Map<string, Promise<vm.Module>>();
 
   /**
    * Performs the actual loading of module source from disk, creates the
-   * SourceTextModule instance, and maintains the module cache.
+   * Module instance, and maintains the module cache.
    *
    * Used directly by `importModule` and by the linker and dynamic import()
    * support function.
@@ -126,7 +119,7 @@ export const importModule = async (
   const loadModule = async (
     specifier: string,
     referrer: string
-  ): Promise<vm.SourceTextModule> => {
+  ): Promise<vm.Module> => {
     const moduleURL = resolveSpecifier(specifier, referrer);
     if (moduleURL.protocol !== 'file:') {
       throw new Error(`Unsupported protocol: ${moduleURL.protocol}`);
@@ -137,15 +130,27 @@ export const importModule = async (
       return modulePromise;
     }
     modulePromise = (async () => {
-      const source = await readFile(modulePath, 'utf-8');
-      // TODO: store and re-use cachedData:
-      // https://nodejs.org/api/vm.html#vm_constructor_new_vm_sourcetextmodule_code_options
-      return new vm.SourceTextModule(source, {
-        initializeImportMeta,
-        importModuleDynamically,
-        context,
-        identifier: moduleURL.toString() + `:${importId++}`,
-      });
+      // Provide basic support for built-in modules (needed for node shims of
+      // DOM API's like fetch)
+      if (builtIns.has(specifier)) {
+        const mod = await import(specifier);
+        return new vm.SyntheticModule(Object.keys(mod), function() {
+          Object.keys(mod).forEach(key => this.setExport(key, mod[key]));
+        }, {
+          context,
+          identifier: specifier + `:${vmContextId}`,
+        });
+      } else {
+        const source = await fs.readFile(modulePath, 'utf-8');
+        // TODO: store and re-use cachedData:
+        // https://nodejs.org/api/vm.html#vm_constructor_new_vm_sourcetextmodule_code_options
+        return new vm.SourceTextModule(source, {
+          initializeImportMeta,
+          importModuleDynamically,
+          context,
+          identifier: moduleURL.toString() + `:${vmContextId}`,
+        });
+      }
     })();
     moduleCache.set(modulePath, modulePromise);
     return modulePromise;
@@ -156,14 +161,14 @@ export const importModule = async (
    */
   const linker = async (
     specifier: string,
-    referencingModule: vm.SourceTextModule
-  ): Promise<vm.SourceTextModule> => {
+    referencingModule: vm.Module
+  ): Promise<vm.Module> => {
     return loadModule(specifier, referencingModule.identifier);
   };
 
   const importModuleDynamically = async (
     specifier: string,
-    referencingModule: vm.SourceTextModule
+    referencingModule: vm.Module
   ) => {
     return _importModule(specifier, referencingModule.identifier);
   };

--- a/src/lib/render-html-file-impl.ts
+++ b/src/lib/render-html-file-impl.ts
@@ -1,0 +1,72 @@
+import { render } from './render-lit-html.js';
+import { TemplateResult, defaultTemplateProcessor } from 'lit-html';
+import { promises as fs } from 'fs';
+import path from 'path';
+import fetch from 'node-fetch';
+import {URL} from 'url';
+
+interface RenderAppOptions {
+  url: string;
+  root: string;
+  fallback: string;
+  env: {[key: string]: any}
+}
+
+interface InitializeSSRModule {
+  initializeSSR?: (location: string) => void | Promise<unknown>;
+}
+
+/**
+ * Process to render an HTML file for a given URL:
+ * 1. Read the specified HTML file
+ * 2. Find all `<script>` tags marked with `ssr` attribute and dynamically
+ *    import them
+ * 3. If the module exported an `initializeSSR` method, call and await its
+ *    result
+ * 4. If `initializeSSR` returned a values array, push those values onto the the
+ *    dynamic values to render the page with
+ * 5. Split the HTML file contents on the `<!--lit-ssr-value-->` markers
+ * 6. Return a TemplateResult constructed from the HTML page's contents and the
+ *    values returned from initializeSSR.
+ */
+export async function renderFile(options: RenderAppOptions) {
+  // Shim some useful globals onto window
+  const url = new URL(options.url);
+  Object.assign(window, {
+    location: url,
+    fetch,
+    process: {env: {NODE_ENV: 'production', ...options.env || {}}}
+  });
+  debugger
+  // Make sure file exists; if not, use fallback
+  let file = path.join(options.root, url.pathname);
+  let exists = false;
+  try {
+    exists = (await fs.stat(file)).isFile();
+  } catch {}
+  if (!exists) {
+    file = path.join(options.root, options.fallback);
+  }
+  // Read file
+  const content = await fs.readFile(file, 'utf-8');
+  // Load `ssr`-tagged scripts
+  const scripts = Array.from(content.matchAll(/<script[^>]* src="([^"]+)" ssr>/g)).map(m => m[1]);
+  const values = [];
+  for (const script of scripts) {
+    const module = await import(path.join(options.root, script));
+    if ((module as InitializeSSRModule).initializeSSR) {
+      const ret = await module.initializeSSR(url);
+      if (Array.isArray(ret)) {
+        values.push(...ret);
+      }
+    }
+  }
+  // Split strings for any interpolated values
+  const strings = content.split('<!--lit-ssr-value-->');
+  if (strings.length-1 !== values.length) {
+    throw new Error(`Number of <!--lit-ssr-value--> comments (${strings.length-1}) and initializeSSR()-returned values (${values.length}) did not match.`)
+  }
+  // Construct a TemplateResult
+  const result = new TemplateResult(strings as unknown as TemplateStringsArray, values, 'html', defaultTemplateProcessor);
+  return render(result);
+};

--- a/src/lib/render-html-file.ts
+++ b/src/lib/render-html-file.ts
@@ -1,0 +1,67 @@
+import Koa from 'koa';
+import {renderModule} from './render-module.js';
+import { IterableReader } from './util/iterator-readable.js';
+
+import * as path from 'path';
+
+export interface RenderHTMLFileOptions {
+  /** The HTTP root folder, for resolving URL paths to static files */
+  root: string;
+  /** A fallback file to use if the specified URL did not exist */
+  fallback: string;
+};
+
+/**
+ * Koa middleware for rendering HTML files using render-lit-html.
+ *
+ * This middleware will only handle URLs to files with `.html` or bare paths
+ * with `accept: text/html` or `accept: *`. If a static file does not exist at
+ * the specified URL path, the `fallback` file will be rendered/served.
+ *
+ * Any `<script>` tags that should be loaded & run on the server prior to
+ * rendering should be marked with an `ssr` attribute.  If any of these scripts
+ * are modules that have an `initializeSSR` export, it will be invoked and
+ * awaited prior to rendering.  If any `initializeSSR` methods resolve to arrays
+ * of values, those values will be interpolated into `<!--lit-ssr-value-->`
+ * comment markers found in the page.
+ *
+ * @param options 
+ */
+export const renderHTMLFile =
+  (options: RenderHTMLFileOptions) => 
+    async (ctx: Koa.ParameterizedContext<Koa.DefaultState, Koa.DefaultContext>, next: Koa.Next) => {
+      // Only handle GET's
+      if (ctx.method !== 'GET') {
+        return next();
+      }
+      // Only handle .html extension or bare paths
+      const ext = path.extname(ctx.path);
+      if (ext && ext !== '.html') {
+        return next();
+      }
+      // Only handle HTML or *, but never JSON
+      if (!ctx.headers || typeof ctx.headers.accept !== 'string') {
+        return next();
+      }
+      if (ctx.headers.accept.includes('application/json')) {
+        return next();
+      }
+      if (!(ctx.headers.accept.includes('text/html') || ctx.headers.accept.includes('*/*'))) {
+        return next();
+      }
+      // Render the file using a new VM context for each request
+      const ssrResult = await (renderModule(
+        './render-html-file-impl.js',
+        import.meta.url,
+        'renderFile',
+        [{url: ctx.href, root: options.root, fallback: options.fallback}]
+      ));
+      const stream = new IterableReader(ssrResult);
+      stream.on('error', (e) => {
+        console.error(e.message);
+        console.error(e.stack);
+      });
+      ctx.type = 'text/html';
+      ctx.body = stream;
+      return;
+    };

--- a/src/lib/render-module.ts
+++ b/src/lib/render-module.ts
@@ -1,10 +1,6 @@
-import {window} from '../lib/dom-shim.js';
+import {getWindow} from '../lib/dom-shim.js';
 import {importModule} from './import-module.js';
 import {createRequire} from 'module';
-
-// We need to give window a require to load CJS modules used by the SSR
-// implementation. If we had only JS module dependencies, we wouldn't need this.
-(window as any).require = createRequire(import.meta.url);
 
 /**
  * Imports a module into a web-like rendering VM content and calls the function
@@ -21,6 +17,11 @@ export const renderModule = async (
   functionName: string,
   args: any[]
 ) => {
+  const window = getWindow({
+    // We need to give window a require to load CJS modules used by the SSR
+    // implementation. If we had only JS module dependencies, we wouldn't need this.
+    require: createRequire(import.meta.url),
+  });
   const module = await importModule(specifier, referrer, window);
   const f = module.namespace[functionName] as Function;
   // TODO: should we require the result be an AsyncIterable?

--- a/src/test/integration/server/server.ts
+++ b/src/test/integration/server/server.ts
@@ -17,15 +17,12 @@ import Koa from 'koa';
 import Router from '@koa/router';
 
 import {importModule} from '../../../lib/import-module.js';
-import {window} from '../../../lib/dom-shim.js';
+import {getWindow} from '../../../lib/dom-shim.js';
 import {IterableReader} from '../../../lib/util/iterator-readable.js';
 
 import * as testModule from '../tests/basic-ssr.js';
 import { SSRTest } from "../tests/ssr-test";
 
-// We need to give window a require to load CJS modules used by the SSR
-// implementation. If we had only JS module dependencies, we wouldn't need this.
-(window as any).require = createRequire(import.meta.url);
 
 export const startServer = async (port = 9090) => {
   const app = new Koa();
@@ -35,6 +32,11 @@ export const startServer = async (port = 9090) => {
     const suiteName = context.params.suite;
     const testName = context.params.test;
 
+    const window = getWindow({
+      // We need to give window a require to load CJS modules used by the SSR
+      // implementation. If we had only JS module dependencies, we wouldn't need this.
+      require: createRequire(import.meta.url)
+    });
     const {namespace} = await importModule(`../tests/${suiteName}-ssr.js`, import.meta.url, window);
     const module = namespace as typeof testModule;
 

--- a/src/test/integration/tests/basic.ts
+++ b/src/test/integration/tests/basic.ts
@@ -24,6 +24,8 @@ import {asyncReplace} from 'lit-html/directives/async-replace.js';
 import {TestAsyncIterable} from 'lit-html/test/lib/test-async-iterable.js';
 import {ifDefined} from 'lit-html/directives/if-defined.js';
 import {live} from 'lit-html/directives/live.js';
+import {unsafeHTML} from 'lit-html/directives/unsafe-html.js';
+import {unsafeSVG} from 'lit-html/directives/unsafe-svg.js';
 
 import { LitElement, property } from 'lit-element';
 import {renderLight} from 'lit-element/lib/render-light.js';
@@ -688,6 +690,40 @@ export const tests: {[name: string] : SSRTest} = {
       {
         args: [undefined],
         html: '<div></div>',
+      },
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts directive: unsafeHTML': {
+    render(v) {
+      return html`<div>${unsafeHTML(v)}</div>`
+    },
+    expectations: [
+      {
+        args: ['<span foo="bar"></span>'],
+        html: '<div><span foo="bar"></span></div>',
+      },
+      {
+        args: ['<p bar="foo"></p>'],
+        html: '<div><p bar="foo"></p></div>',
+      },
+    ],
+    stableSelectors: ['div'],
+  },
+
+  'NodePart accepts directive: unsafeSVG': {
+    render(v) {
+      return html`<svg>${unsafeSVG(v)}</svg>`
+    },
+    expectations: [
+      {
+        args: ['<circle cx="50" cy="50" r="40" />'],
+        html: '<svg><circle cx="50" cy="50" r="40"></circle></svg>',
+      },
+      {
+        args: ['<ellipse cx="100" cy="50" rx="100" ry="50" />'],
+        html: '<svg><ellipse cx="100" cy="50" rx="100" ry="50"></ellipse></svg>',
       },
     ],
     stableSelectors: ['div'],

--- a/src/test/lit/render-lit_test.ts
+++ b/src/test/lit/render-lit_test.ts
@@ -14,14 +14,12 @@
 
 import {createRequire} from 'module';
 import {importModule} from '../../lib/import-module.js';
-import {window} from '../../lib/dom-shim.js';
+import {getWindow} from '../../lib/dom-shim.js';
 import tape, {Test} from 'tape';
 import tapePromiseLib from 'tape-promise';
 
 const tapePromise = (tapePromiseLib as any).default as typeof tapePromiseLib;
 const test = tapePromise(tape);
-
-(window as any).require = createRequire(import.meta.url);
 
 /**
  * Promise for importing the "app module". This is a module that implements the
@@ -31,7 +29,7 @@ const test = tapePromise(tape);
 const appModuleImport = importModule(
   '../test-files/render-test-module.js',
   import.meta.url,
-  window
+  getWindow({require: createRequire(import.meta.url)})
 );
 
 /* Real Tests */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "esnext",
-    "lib": ["es2019"],
+    "lib": ["es2019", "ES2020.String"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
* Makes `dom-shim` a factory to return a unique `window` object per call to `importModule`
* Adds `node-fetch` shim for `fetch` to `dom-shim`, along with a couple other required globals for it
* Adds support to `importModule` for importing built-in node modules in VM context (required for e.g. `node-fetch`)
* Ensures identifier for VM modules is unique per VM context (important to avoid caching issues with dynamic imports)
* Adds Koa middleware for rendering static HTML files through `render-lit-html`
  * Scripts to be loaded on server should be marked with `ssr` attribute
  * Scripts to be loaded _only_ on server (e.g. for fetching/initializing data) can be marked with `type="ssr-only"` to prevent loading on client
  * If a module script loaded on the server exports an `initializeSSR` method, it will be invoked & awaited
  * If `initializeSSR` returns any values, they will be interpolated into `<!--lit-ssr-value-->` markers placed in the HTML file

Associated PR's:
* https://github.com/PolymerLabs/lit-ssr-hacker-news/pull/1
* https://github.com/Polymer/lit-html/pull/1179