### PR TITLE
Add support for CE attribute rendering.

### DIFF
--- a/src/lib/lit-element-renderer.ts
+++ b/src/lib/lit-element-renderer.ts
@@ -56,7 +56,7 @@ export class LitElementRenderer extends ElementRenderer {
       yield '</style>';
     }
     // Render template
-    yield* render((this.element as any).render(), {deferChildHydration: true});
+    yield* render((this.element as any).render());
     // Close shadow root
     yield '</template>';
   }

--- a/src/lib/lit-element-renderer.ts
+++ b/src/lib/lit-element-renderer.ts
@@ -13,59 +13,60 @@
  */
 
 import {ElementRenderer} from './element-renderer.js';
-import {LitElement, TemplateResult, CSSResult} from 'lit-element';
+import {LitElement, CSSResult} from 'lit-element';
 import {render, renderValue, RenderInfo} from './render-lit-html.js';
 
 export type Constructor<T> = {new (): T};
 
-/**
- * An object that renders elements of a certain type.
- */
-export class LitElementRenderer implements ElementRenderer {
-  constructor(public element: LitElement) {}
+// No-op LitElement's client-side render method, since we will call
+// `performUpdate` directly on the server
+LitElement.render = () => {};
 
-  *renderElement(): IterableIterator<string> {
-    const renderResult = ((this.element as unknown) as {
-      render(): TemplateResult;
-    }).render();
+/**
+ * ElementRenderer implementation for LitElements
+ */
+export class LitElementRenderer extends ElementRenderer {
+  constructor(public element: LitElement) {
+    super(element);
+  }
+
+  connectedCallback() {
+    (this.element as any).enableUpdating();
+    (this.element as any).performUpdate(false);
+  }
+
+  attributeChangedCallback(name: string, old: string | null, value: string | null) {
+    if (old !== value) {
+      (this.element as any)._attributeToProperty(name, value);
+    }
+  }
+
+  *renderChildren(): IterableIterator<string> {
+    // Open shadow root
     yield '<template shadowroot="open">';
     // Render styles.
-    const ctor = customElements.get(this.element.tagName!);
-    const styles = [(ctor as any).styles].flat(Infinity);
-    let hasCssResult = false;
-    for (const style of styles) {
-      if (style instanceof CSSResult) {
-        if (!hasCssResult) {
-          hasCssResult = true;
-          yield '<style>';
-        }
-        // TODO(sorvell): support ShadyCSS transformed styles. These should
-        // be written once.
-        //const scoped = StyleTransformer.css(style.cssText, tagName);
-        yield style.cssText;
+    const styles = [(this.element.constructor as typeof LitElement).styles]
+      .flat(Infinity)
+      .filter(style => style instanceof CSSResult);
+    if (styles.length) {
+      yield '<style>';
+      for (const style of styles) {
+        yield (style as CSSResult).cssText;
       }
-    }
-    if (hasCssResult) {
       yield '</style>';
     }
-    yield* render(renderResult);
+    // Render template
+    yield* render((this.element as any).render(), {deferChildHydration: true});
+    // Close shadow root
     yield '</template>';
   }
 
-  setProperty(name: string, value: unknown) {
-    (this.element as any)[name] = value;
-  }
-
-  setAttribute(name: string, value: string | null) {
-    // Note, this should always exist for LitElement, but we're not yet
-    // explicitly checking for LitElement.
-    if (this.element.attributeChangedCallback) {
-      this.element.attributeChangedCallback(name, null, value as string);
+  *renderLight (renderInfo: RenderInfo): IterableIterator<string> {
+    const value = (this.element as any)?.renderLight();
+    if (value) {
+      yield* renderValue(value, renderInfo);
+    } else {
+      yield '';
     }
-  }
-
-  renderLight(renderInfo: RenderInfo) {
-    const templateResult = (this.element as any)?.renderLight();
-    return templateResult ? renderValue(templateResult, renderInfo) : '';
   }
 }

--- a/src/lib/render-lit-html.ts
+++ b/src/lib/render-lit-html.ts
@@ -420,13 +420,8 @@ const getTemplate = (result: TemplateResult) => {
   return t;
 };
 
-export type SSRRenderOptions = {
-  deferChildHydration?: boolean;
-};
-
 export type RenderInfo = {
   customElementInstanceStack: Array<ElementRenderer | undefined>;
-  options: SSRRenderOptions;
 };
 
 declare global {
@@ -452,8 +447,8 @@ export const getScopedStyles = () => {
   return scopedStyles;
 };
 
-export function* render(value: unknown, options: SSRRenderOptions = {}): IterableIterator<string> {
-  yield* renderValue(value, {customElementInstanceStack: [], options});
+export function* render(value: unknown): IterableIterator<string> {
+  yield* renderValue(value, {customElementInstanceStack: []});
 }
 
 export function* renderValue(
@@ -619,9 +614,6 @@ export function* renderTemplateResult(
         if (instance !== undefined) {
           if (instance.connectedCallback) {
             instance.connectedCallback();
-          }
-          if (renderInfo.options.deferChildHydration) {
-            yield ' defer-hydration';
           }
           yield* instance.renderAttributes();
         }

--- a/src/lib/util/escaping.ts
+++ b/src/lib/util/escaping.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+// http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#escapingString
+const escapeAttrRegExp = /[&\u00A0"]/g;
+const escapeDataRegExp = /[&\u00A0<>]/g;
+
+const escapeReplace = (c: string) => {
+  switch (c) {
+    case '&':
+      return '&amp;';
+    case '<':
+      return '&lt;';
+    case '>':
+      return '&gt;';
+    case '"':
+      return '&quot;';
+    case '\u00A0':
+      return '&nbsp;';
+  }
+  throw new Error('unexpected');
+}
+
+export const escapeAttribute = (s: string) => {
+  return s.replace(escapeAttrRegExp, escapeReplace);
+}
+
+export const escapeTextContent = (s: string) => {
+  return s.replace(escapeDataRegExp, escapeReplace);
+}

--- a/src/test/integration/client/basic_test.ts
+++ b/src/test/integration/client/basic_test.ts
@@ -25,6 +25,9 @@ LitElement.hydrate = hydrate;
 
 const assert = chai.assert;
 
+// Types don't seem to include options argument
+const assertLightDom: ((el: Element | ShadowRoot, str: string, opt: any) => void) = assert.lightDom.equal;
+
 /**
  * Checks a tree of expected HTML against the DOM; the expected HTML can either
  * be a string or an object containing keys of querySelector queries mapped to
@@ -70,7 +73,7 @@ const assertHTML = (container: Element | ShadowRoot, html: SSRExpectedHTML): voi
       const subHtml = html[query];
       if (query === 'root') {
         assert.typeOf(subHtml, 'string', `html expectation for ':root' must be a string.`);
-        assert.lightDom.equal(container, subHtml as string);
+        assertLightDom(container, subHtml as string, {ignoreAttributes: ['defer-hydration']});
       } else {
         const subContainers = Array.from(container.querySelectorAll(query))
         ;

--- a/src/test/integration/tests/basic.ts
+++ b/src/test/integration/tests/basic.ts
@@ -3311,11 +3311,6 @@ export const tests: {[name: string] : SSRTest} = {
 
   'LitElement: Reflected property binding': () => {
     return {
-      // TODO: lit-element-renderer does not yet support reflected properties;
-      // should the renderer call into `addPropertiesForElement`? The first time
-      // a renderer is created for a given element type?
-      // https://github.com/PolymerLabs/lit-ssr/issues/61
-      skip: true,
       registerElements() {
         class LEReflectedBinding extends LitElement {
           @property({reflect: true})
@@ -3345,7 +3340,7 @@ export const tests: {[name: string] : SSRTest} = {
         {
           args: ['boundProp2'],
           async check(assert: Chai.Assert, dom: HTMLElement) {
-            const el = dom.querySelector('le-prop-binding')! as LitElement;
+            const el = dom.querySelector('le-reflected-binding')! as LitElement;
             await el.updateComplete;
             assert.strictEqual((el as any).prop, 'boundProp2');
           },
@@ -3356,6 +3351,10 @@ export const tests: {[name: string] : SSRTest} = {
         },
       ],
       stableSelectors: ['le-reflected-binding'],
+      // LitElement unconditionally sets reflecting properties to attributes
+      // on a property change, even if the attribute was already there
+      expectMutationsDuringUpgrade: true,
+      expectMutationsDuringHydration: true,
     };
   },
 
@@ -3377,9 +3376,10 @@ export const tests: {[name: string] : SSRTest} = {
       expectations: [
         {
           args: ['boundProp1'],
-          async check(_assert: Chai.Assert, dom: HTMLElement) {
+          async check(assert: Chai.Assert, dom: HTMLElement) {
             const el = dom.querySelector('le-attr-binding')! as LitElement;
             await el.updateComplete;
+            assert.strictEqual((el as any).prop, 'boundProp1');
           },
           html: {
             root: `<le-attr-binding prop="boundProp1"></le-attr-binding>`,
@@ -3388,9 +3388,10 @@ export const tests: {[name: string] : SSRTest} = {
         },
         {
           args: ['boundProp2'],
-          async check(_assert: Chai.Assert, dom: HTMLElement) {
+          async check(assert: Chai.Assert, dom: HTMLElement) {
             const el = dom.querySelector('le-attr-binding')! as LitElement;
             await el.updateComplete;
+            assert.strictEqual((el as any).prop, 'boundProp2');
           },
           html: {
             root: `<le-attr-binding prop="boundProp2"></le-attr-binding>`,


### PR DESCRIPTION
* Adds minimal attribute API to the dom-shim
* Refactored custom-element opcodes:
  * `custom-element-open` creates `ElementRenderer` and CE instance and calls `ElementRenderer:setAttribute()` for all static attributes
  * `attribute-part`: runs in between the `custom-element-open` and `custom-element-attributes` opcodes, to ensure any property/attribute bindings are set on the element before serializing the attributes
  * `custom-element-attributes`: runs `ElementRenderer:connectedCallback()`, and then renders attributes via `ElementRenderer:renderAttributes()` (default implementation serializes the dom-shim's attributes collection)
  * `custom-element-children`: renders the CE children via `ElementRenderer:renderAttributes()`
* `lit-element-renderer.ts` no-ops the client-side `LitElement.render`, and then implements new `connectedCallback` and `attributeChangedCallback` abstract methods to call protected `UpdatingElement` lifecycle.
* Note that `LitElement:performUpdate()` is called with a new flag to elide the `(first)updated` callbacks, since these (a) can't do anything good to the SSR output since they occur after `render()`, and (b) may more likely touch DOM.
* Escapes all attribute & textContent values (resolves TODO in code)